### PR TITLE
fix: disable verbatimmodulesyntax for cjs build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": ["ES2022"],
     "allowJs": true,
     "noEmit": true,
-    "moduleDetection": "force"
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": false
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["coverage", "dist", "docs", "node_modules"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts TypeScript config to improve CommonJS compatibility.
> 
> - Sets `compilerOptions.verbatimModuleSyntax` to `false` in `tsconfig.json`
> - Retains `moduleDetection: "force"`; no other config or source changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4462c34fedcf4ddac54a3b601f2e6094c86e6835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->