### PR TITLE
ci: configure npm publishing with oidc provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
       - main
 
 permissions:
-  contents: read # for checkout
+  contents: read
 
 jobs:
   test:
@@ -15,10 +15,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
@@ -26,22 +26,24 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: '9'
+          version: "9"
           run_install: false
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: pnpm install
       - run: pnpm run build
-      - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
+      - name: Verify the integrity of provenance attestations and registry signatures
         run: npm audit signatures
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release
   docs:
     needs: release
@@ -55,22 +57,19 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: '9'
+          version: "9"
           run_install: false
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
       - run: pnpm run doc
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        # If you're changing the branch from main,
-        # also change the `main` in `refs/heads/main`
-        # below accordingly.
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs  
+          publish_dir: ./docs


### PR DESCRIPTION
Changes:
- Add registry-url to setup-node
- Use NODE_AUTH_TOKEN instead of NPM_TOKEN directly
- Enable NPM_CONFIG_PROVENANCE for attestation
- Keep id-token: write for OIDC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures npm publishing in `release.yml` to use OIDC provenance and standardizes workflow config.
> 
> - Adds `registry-url` to `actions/setup-node` and switches to `NODE_AUTH_TOKEN` with `NPM_CONFIG_PROVENANCE=true` for `semantic-release`
> - Ensures `id-token: write` and clarifies top-level and job `permissions` blocks
> - Renames the verification step and keeps `npm audit signatures` for dependency signature checks
> - Normalizes quoting and minor formatting in release/docs workflows (no functional changes to docs build/deploy)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd7a6d1ea98b6268ac746739ccfc4738f4e658ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->