### PR TITLE
ci: add npm token for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
-      - name: Publish to npm with OIDC provenance
+      - name: Publish to npm with provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public || echo "Publish skipped (no new version or already published)"
   docs:
     needs: release


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches npm publish authentication in the release workflow to use `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN`.
> 
> - Updates release job step to "Publish to npm with provenance" and sets `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
> - Keeps `semantic-release` for versioning before publish; publish command unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99d3af1a4bc2f77e988d0876ec8c7c3148c395f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->