### PR TITLE
fix: add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,9 @@
     "typedoc": "^0.27.0",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.46.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jmlweb/mochila.git"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds missing package metadata to support npm provenance.
> 
> - Adds `repository` field to `package.json` pointing to `https://github.com/jmlweb/mochila.git`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3962d95751a8d7c48fa6b832057bbf071f6d4005. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->