### PR TITLE
fix: use bracket notation for index signature properties in tests

### DIFF
--- a/src/fromEntries/fromEntries.test.ts
+++ b/src/fromEntries/fromEntries.test.ts
@@ -72,8 +72,8 @@ describe('fromEntries', () => {
     ];
     const result = fromEntries(entries);
 
-    expect(result.user).toBe(obj1);
-    expect(result.config).toEqual({ theme: 'dark' });
+    expect(result['user']).toBe(obj1);
+    expect(result['config']).toEqual({ theme: 'dark' });
   });
 
   test('handles numeric string keys', () => {


### PR DESCRIPTION
TypeDoc was failing because it requires bracket notation for properties coming from an index signature.

**Changes:**
- `result.user` → `result["user"]`
- `result.config` → `result["config"]`

This fixes the docs generation workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates tests to access index-signature-backed properties with bracket notation.
> 
> - In `src/fromEntries/fromEntries.test.ts`, replace `result.user`/`result.config` with `result['user']`/`result['config']` in the object values test
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91ba2b309cc60dc265c755c5299c1b7a747ca633. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->